### PR TITLE
Change logging directory

### DIFF
--- a/VRCModLogger.cs
+++ b/VRCModLogger.cs
@@ -21,8 +21,8 @@ namespace VRCModLoader
             DirectoryInfo logDirInfo = null;
             FileInfo logFileInfo;
 
-            string logFilePath = CombinePaths(Application.persistentDataPath, "Logs", "VRCModLoader");
-            // string logFilePath = CombinePaths(Environment.CurrentDirectory, "Logs", "VRCModLoader");
+            //string logFilePath = CombinePaths(Application.persistentDataPath, "Logs", "VRCModLoader");
+            string logFilePath = CombinePaths(Environment.CurrentDirectory, "Logs", "VRCModLoader");
             logFilePath = logFilePath + "/VRCModLoader_" + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss-fff") + ".log";
             logFileInfo = new FileInfo(logFilePath);
             logDirInfo = new DirectoryInfo(logFileInfo.DirectoryName);

--- a/VRCModLogger.cs
+++ b/VRCModLogger.cs
@@ -9,13 +9,20 @@ namespace VRCModLoader
         internal static bool consoleEnabled = false;
         private static StreamWriter log;
 
+        internal static string CombinePaths(params string[] paths)
+        {
+            if (paths == null) throw new ArgumentNullException("paths");
+            return paths.Aggregate(Path.Combine);
+        }
+
         internal static void Init()
         {
             FileStream fileStream = null;
             DirectoryInfo logDirInfo = null;
             FileInfo logFileInfo;
 
-            string logFilePath = Path.Combine(Environment.CurrentDirectory, "Logs" + Path.DirectorySeparatorChar + "VRCModLoader");
+            string logFilePath = CombinePaths(Application.persistentDataPath, "Logs", "VRCModLoader");
+            // string logFilePath = CombinePaths(Environment.CurrentDirectory, "Logs", "VRCModLoader");
             logFilePath = logFilePath + "/VRCModLoader_" + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss-fff") + ".log";
             logFileInfo = new FileInfo(logFilePath);
             logDirInfo = new DirectoryInfo(logFileInfo.DirectoryName);

--- a/VRCModLogger.cs
+++ b/VRCModLogger.cs
@@ -15,7 +15,7 @@ namespace VRCModLoader
             DirectoryInfo logDirInfo = null;
             FileInfo logFileInfo;
 
-            string logFilePath = Path.Combine(Environment.CurrentDirectory, "Logs");
+            string logFilePath = Path.Combine(Environment.CurrentDirectory, "Logs" + Path.DirectorySeparatorChar + "VRCModLoader");
             logFilePath = logFilePath + "/VRCModLoader_" + DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss-fff") + ".log";
             logFileInfo = new FileInfo(logFilePath);
             logDirInfo = new DirectoryInfo(logFileInfo.DirectoryName);


### PR DESCRIPTION
Tbh, maybe even change it to a subfolder of the "normal" vrchat logging directory (if you find the function to dynamically get the path in the VRC code)

Reason: When using something like SpecialK there already will be a "logs" directory in the game dir (Example:


![](https://i.imgur.com/28LOFAz.png)

https://docs.unity3d.com/Manual/LogFiles.html#Player